### PR TITLE
libpostal 1.1 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,7 +4,7 @@ set -ex
 # sse2 seems to be being enabled on ARM64
 conf_args=()
 case "$(uname -m)" in
-arm64|aarch64)
+arm64|aarch64|x390x)
     conf_args+=( --disable-sse2 )
     ;;
 esac

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,18 @@
+set -ex
 ./bootstrap.sh
-./configure --datadir=$PREFIX/share/libpostal_data --prefix=$PREFIX
+
+# sse2 seems to be being enabled on ARM64
+conf_args=()
+case "$(uname -m)" in
+arm64|aarch64)
+    conf_args+=( --disable-sse2 )
+    ;;
+esac
+
+./configure \
+    --datadir=$PREFIX/share/libpostal_data \
+    --prefix=$PREFIX \
+    "${conf_args[@]}"
 
 make -j${CPU_COUNT}
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,8 +3,8 @@ set -ex
 
 # sse2 seems to be being enabled on ARM64
 conf_args=()
-case "$(uname -m)" in
-arm64|aarch64|s390x)
+case "${target_platform}" in
+linux-64|linux-aarch64|osx-arm64|linux-s390x)
     conf_args+=( --disable-sse2 )
     ;;
 esac

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,7 +4,7 @@ set -ex
 # sse2 seems to be being enabled on ARM64
 conf_args=()
 case "$(uname -m)" in
-arm64|aarch64|x390x)
+arm64|aarch64|s390x)
     conf_args+=( --disable-sse2 )
     ;;
 esac

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,17 @@
-{% set version = "1.1.0" %}
+{% set name = "libpostal" %}
+{% set version = "1.1" %}
 
 package:
-  name: libpostal
+  name: {{ name }}
   version: "{{ version }}"
 
 source:
-  url: https://github.com/openvenues/libpostal/archive/refs/tags/v1.1.tar.gz
-  sha256: a93ae1130b102c61c8f55433bdd55bcd6ddb617102c1ee7aee767b86eef1e176
+  url: https://github.com/openvenues/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 8cc473a05126895f183f2578ca234428d8b58ab6fadf550deaacd3bd0ae46032
 
 build:
-  number: 3
+  number: 0
+  # no conda-based autoconf on Windows
   skip: True  # [win]
 
 requirements:
@@ -41,6 +43,13 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: C library for parsing/normalizing street addresses around the world.
+  description: |
+    libpostal is a C library for parsing/normalizing street addresses
+    around the world using statistical NLP and open data. The goal of
+    this project is to understand location-based strings in every
+    language, everywhere.
+  doc_url: https://github.com/openvenues/libpostal
+  dev_url: https://github.com/openvenues/libpostal
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
libpostal 1.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5362]
- dev_url:        https://github.com/openvenues/libpostal/tree/v1.1
- conda_forge:    https://github.com/conda-forge/libpostal-feedstock/blob/main/recipe/meta.yaml
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- basic build
  - the SHA256 probably changed from conda-forge when GH switched their archive algorithm
  - `arm64`/`aarch64` were picking up the need to use Intel's `SSE2` instructions
  - no `make test` "make: Nothing to be done for 'test'." 🤔 
    - it does create `test/test_libpostal` which you can run _in situ_ but doesn't like to be copied (as it wants lots of supporting `.o` and `.so` files)


[PKG-5362]: https://anaconda.atlassian.net/browse/PKG-5362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ