### PR TITLE
libpostal 1.1_1 :snowflake:

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,22 +10,23 @@ set -eu
 # below.
 
 mkdir -p ${PREFIX}/share/libpostal_data
-mv __upstream/share/libpostal_data/libpostal ${PREFIX}/share/libpostal_data
+# We might like to use install rather than mv/cp but this is a
+# hierarchy of files which install doesn't handle
+cp -rp __upstream/share/libpostal_data/libpostal ${PREFIX}/share/libpostal_data
 
 # XXX if the data_version file is wrong it will delete all of the
 # libpostal data
-for vf in data_version ; do
-    vfile=${PREFIX}/share/libpostal_data/libpostal/${vf}
-    # Where does "v1" come from?
-    #
-    # grep LIBPOSTAL_DATA_DIR_VERSION_STRING configure*
-    #
-    # Also LIBPOSTAL_SENZING_DATA_DIR_VERSION_STRING
-    echo v1 > ${vfile}
-done
+#
+# Where does "v1" come from?
+#
+# grep LIBPOSTAL_DATA_DIR_VERSION_STRING configure*
+#
+# Also LIBPOSTAL_SENZING_DATA_DIR_VERSION_STRING
+echo v1 > ${PREFIX}/share/libpostal_data/libpostal/data_version
+
 for vf in base_data_file_version \
-	      parser_model_file_version \
-	      language_classifier_model_file_version ; do
+	  parser_model_file_version \
+	  language_classifier_model_file_version ; do
     vfile=${PREFIX}/share/libpostal_data/libpostal/${vf}
     # v1.0.0 is the recipe's package.version
     echo v1.0.0 > ${vfile}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,31 @@
-set -ex
+#! /bin/bash
+
+set -eu
+
 ./bootstrap.sh
+
+# We have pre-downloaded the data files.  bin/libpostal_data will
+# update these files if necessary which you can verify by removing the
+# --disable-data-download from configure, below.
+
+mkdir -p ${PREFIX}/share/libpostal_data
+mv __upstream/share/libpostal_data/libpostal ${PREFIX}/share/libpostal_data
+
+# XXX if the data_version file is wrong it will delete all of the
+# libpostal data
+for vf in data_version ; do
+    vfile=${PREFIX}/share/libpostal_data/libpostal/${vf}
+    # Where does "v1" come from?  grep LIBPOSTAL_DATA_DIR_VERSION_STRING configure*
+    # Also LIBPOSTAL_SENZING_DATA_DIR_VERSION_STRING
+    echo v1 > ${vfile}
+done
+for vf in base_data_file_version \
+	      parser_model_file_version \
+	      language_classifier_model_file_version ; do
+    vfile=${PREFIX}/share/libpostal_data/libpostal/${vf}
+    # v1.0.0 is the recipe's package.version
+    echo v1.0.0 > ${vfile}
+done
 
 # sse2 seems to be being enabled on ARM64
 conf_args=()
@@ -10,9 +36,16 @@ linux-64|linux-aarch64|osx-arm64|linux-s390x)
 esac
 
 ./configure \
+    --disable-data-download \
     --datadir=$PREFIX/share/libpostal_data \
     --prefix=$PREFIX \
     "${conf_args[@]}"
 
 make -j${CPU_COUNT}
+
+# We might normally try to run this tester in the test section but it
+# is extremely reluctant to be copied (it complains about missing .o
+# and .so files)
+test/test_libpostal
+
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -39,13 +39,31 @@ esac
     --disable-data-download \
     --datadir=$PREFIX/share/libpostal_data \
     --prefix=$PREFIX \
-    "${conf_args[@]}"
+    "${conf_args:+${conf_args[@]}}"
 
 make -j${CPU_COUNT}
 
 # We might normally try to run this tester in the test section but it
 # is extremely reluctant to be copied (it complains about missing .o
 # and .so files)
-test/test_libpostal
+case "${target_platform}" in
+linux-s390x)
+    # test/test_libpostal -l to get a list of suites & tests
+    test/test_libpostal -s expansion
+    # s390x mixes up city_district/suburb/city/state in a dozen parser
+    # tests: us gb im nz fr es mx cn jp kr za nl da ro ru.  That list
+    # suggests that the Senzing model (improved US, UK and SG) will
+    # not help
+    #test/test_libpostal -s parser
+    test/test_libpostal -s transliteration
+    test/test_libpostal -s numex
+    test/test_libpostal -s string_utils
+    test/test_libpostal -s trie
+    test/test_libpostal -s crf_context
+    ;;
+*)
+    test/test_libpostal
+    ;;
+esac
 
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,9 +4,10 @@ set -eu
 
 ./bootstrap.sh
 
-# We have pre-downloaded the data files.  bin/libpostal_data will
-# update these files if necessary which you can verify by removing the
-# --disable-data-download from configure, below.
+# We have pre-downloaded the data files.  If bin/libpostal_data is run
+# during the build it will update these files if necessary which you
+# can verify by removing the --disable-data-download from configure,
+# below.
 
 mkdir -p ${PREFIX}/share/libpostal_data
 mv __upstream/share/libpostal_data/libpostal ${PREFIX}/share/libpostal_data
@@ -15,7 +16,10 @@ mv __upstream/share/libpostal_data/libpostal ${PREFIX}/share/libpostal_data
 # libpostal data
 for vf in data_version ; do
     vfile=${PREFIX}/share/libpostal_data/libpostal/${vf}
-    # Where does "v1" come from?  grep LIBPOSTAL_DATA_DIR_VERSION_STRING configure*
+    # Where does "v1" come from?
+    #
+    # grep LIBPOSTAL_DATA_DIR_VERSION_STRING configure*
+    #
     # Also LIBPOSTAL_SENZING_DATA_DIR_VERSION_STRING
     echo v1 > ${vfile}
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,9 +6,24 @@ package:
   version: "{{ version }}"
 
 source:
-  url: https://github.com/openvenues/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 8cc473a05126895f183f2578ca234428d8b58ab6fadf550deaacd3bd0ae46032
-
+  - url: https://github.com/openvenues/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 8cc473a05126895f183f2578ca234428d8b58ab6fadf550deaacd3bd0ae46032
+    # These are the data files that {src,bin}/libpostal_data would
+    # download - remember that conda will shift the contents of a
+    # single folder tarball up one level so parser and
+    # language_classifier are put a level further down to counteract
+    # that
+  - url: https://github.com/openvenues/libpostal/releases/download/v1.0.0/libpostal_data.tar.gz
+    sha256: d2ec50587bf3a7e46e18e5dcde32419134266f90774e3956f2c2f90d818ff9a1
+    folder: __upstream/share/libpostal_data/libpostal
+    # parser.tar.gz is downloaded in 12 chunks normally but the whole
+    # 720MB file is available to download directly
+  - url: https://github.com/openvenues/libpostal/releases/download/v1.0.0/parser.tar.gz
+    sha256: 7194e9b0095f71aecb861269f675e50703e73e352a0b9d41c60f8d8ef5a03624
+    folder: __upstream/share/libpostal_data/libpostal/address_parser
+  - url: https://github.com/openvenues/libpostal/releases/download/v1.0.0/language_classifier.tar.gz
+    sha256: 16a6ecb6d37e7e25d8fe514255666852ab9dbd4d9cc762f64cf1e15b4369a277
+    folder: __upstream/share/libpostal_data/libpostal/language_classifier
 build:
   number: 1
   # no conda-based autoconf on Windows

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 8cc473a05126895f183f2578ca234428d8b58ab6fadf550deaacd3bd0ae46032
 
 build:
-  number: 0
+  number: 1
   # no conda-based autoconf on Windows
   skip: True  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,8 @@ source:
 build:
   number: 1
   # no conda-based autoconf on Windows
-  skip: True  # [win]
+  # s390x fails some parser tests
+  skip: True  # [win or s390x]
 
 requirements:
   build:


### PR DESCRIPTION
libpostal 1.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5362]
- dev_url:        https://github.com/openvenues/libpostal/tree/v1.1
- conda_forge:    https://github.com/conda-forge/libpostal-feedstock/blob/main/recipe/meta.yaml
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- bump the build number because the build system lost a previous artifact (`linux-aarch64`'s `.tar.bz2`)
- the main change is to pre-download the data files (800MB) and disable to autodownload during a build
- in addition we're running the internal tests during a build (can't be copied to run during the test phase)
  - though 15 parser tests fail for `s390x` 🤷 (not obviously going to be fixed by switching to Senzing which improves US, UK and SG)
  - `s390x` skipped as this is going to ❄️ 


[PKG-5362]: https://anaconda.atlassian.net/browse/PKG-5362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ